### PR TITLE
Add a way to make the fact numbers in the theme dyanamic

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -23,6 +23,9 @@
       $('.count').each(function () {
         var $this = $(this),
           countTo = $this.attr('data-count');
+	  if(!Number.isInteger(countTo)){
+            countTo = eval(countTo);
+          }
         $({
           countNum: $this.text()
         }).animate(


### PR DESCRIPTION
I'm not sure if this is a hack or a great invention, but i like to share it as a thank you for your amazing theme:

To increase flexablillity of the theme, add a eval if the given content is not a number. In this way a user could add a calculation in javascript like how many days it wil be until a event is happening. This way you get this in the fun facts:

```yaml
######################### funfacts #############################3
    - name: 'Time until we party'
      image: 'images/icons/clock.svg'
      count: 'Math.round((Date.now()-1713175200)/3600000)'
```