### PR TITLE
Update README with steps that lead to a working build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Port-Hugo (A simple portfolio)
 
-currently tested with hugo v0.141.0
+currently tested with hugo v0.141.0 and v0.152.2+extended
 
 This theme is a simple, customizable portfolio for designers or web developers.
 
@@ -20,22 +20,30 @@ This theme is a simple, customizable portfolio for designers or web developers.
 
 ## Install theme on your hugo site
 
+This site makes use of javascript packages that require special installation. As such, things will not "just work" by installing the theme as a submodule the way that Hugo suggests installing themes. The easiest way to get started customizing this theme is to copy certain files into your own project and then start to override and change things as you go.
+
 ```
 hugo new site your-site-name # if you already have a site ignore this line and the next
 cd your-site-name
 cd themes
 git clone https://github.com/tylersayshi/port-hugo.git
-cd port-hugo
-pnpm install # or yarn, npm, bun, etc.
+cd ../ # Go back to the root of your site
+cp port-hugo/exampleSite/{hugo.toml,package.json,postcss.config.js,yarn.lock} . # copy the necessary config files
+cp port-hugo/exampleSite/assets/* ./assets/ # copy necessary assets into your project's assets directory as a starting point
+cp port-hugo/exampleSite/static/* ./static/ # copy necessary static files into your project's static directory as a starting point
+cp port-hugo/exampleSite/data/content.yml ./data/content.yml # copy the content data file into your project as a starting point
+pnpm install # or yarn, npm, bun, etc. - install necessary dependencies
+hugo server -D # launch the hugo server with draft builds included
+# visit http://localhost:1313 to see a site that should look just like the demo site
 ```
 
-Once you have done this, you may use the `exampleSite` folder as an example for how to set your project up. The two main things to pay attention to is to first set this in your `config.toml` file:
+Failure to copy the javascript configuration files, assets, static files, or data file will result in hugo crashing at launch. This is why it's recommended to copy things into your project and then start tweaking from a working website.
+
+If you copied the `hugo.toml` from the exampleSite, your theme will already be set. If you did not, make sure that you have the following set in your `hugo.toml`:
 
 ```toml
 theme = "port-hugo"
 ```
-
-Then you will need to replicate the data used in the `exampleSite/data/content.yaml` file to fill in the fields for your portfolio. Please also see the `exampleSite/config.toml` for guidance on setting up the more general site configurations.
 
 ### Logo support
 


### PR DESCRIPTION
There are either some implicit steps missing from the README, or some things have changed in the repo over time that made the instructions not as useful as they could be. Add more verbosity to the README to help users get to a functional site that they can iterate on.

I don't know if this is the _best_ solution. In theory I think theme could ship the demo assets as part of the theme, but that seems probably unnecessary since everyone will just change them. I _think_ the postcss and javascript files _have_ to be in the root of the project, though maybe they should be in the root of the theme instead? I honestly am not certain how it would behave if I put those files in the theme root, but it does work as expected with them in my project root.

An alternative option could be to provide base versions of necessary files in the theme itself that will get overwritten by the hugo lookup order, and replace image references from `static` and `assets` with maybe external generated placeholder images at runtime (something like https://placehold.co/), that way if the image referenced in the default is missing the build doesn't break? I'm not sure if Hugo's resource system works with external links, I'd guess not.

Either way, I took the bare minimum change approach and just updated the README. I am not an expert in managing packaged themes, I usually just butcher them for my own use. So hopefully this is okay, or can be tweaked to improve the language/experience.

This would close #12